### PR TITLE
Fixed game time formatting

### DIFF
--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -36,7 +36,7 @@ CoverBackground {
     Label{
         visible: game.dimension !== 0
         anchors.horizontalCenter: parent.horizontalCenter
-        text: new Date(null, null, null, null, null, game.time).toTimeString().match(/\d{2}:\d{2}:\d{2}/)[0]
+        text: new Date(null, null, null, null, null, game.time).toLocaleTimeString(Qt.locale(), "HH:mm:ss")
     }
     Rectangle {
 

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -36,7 +36,7 @@ CoverBackground {
     Label{
         visible: game.dimension !== 0
         anchors.horizontalCenter: parent.horizontalCenter
-        text: Math.floor(game.time/3600)%216000+":"+Math.floor(game.time/60)%3600+":"+game.time%60
+        text: new Date(null, null, null, null, null, game.time).toTimeString().match(/\d{2}:\d{2}:\d{2}/)[0]
     }
     Rectangle {
 

--- a/qml/pages/LevelInfos.qml
+++ b/qml/pages/LevelInfos.qml
@@ -92,7 +92,7 @@ Page{
         Label{
             property int time : DB.getTime(diffSelected, levelSelected)
             anchors.horizontalCenter: parent.horizontalCenter
-            text: time===0?"xx:xx:xx":Math.floor(time/3600)%216000+":"+Math.floor(time/60)%3600+":"+time%60
+            text: time===0?"xx:xx:xx":new Date(null, null, null, null, null, time).toTimeString().match(/\d{2}:\d{2}:\d{2}/)[0]
         }
     }
 }

--- a/qml/pages/LevelInfos.qml
+++ b/qml/pages/LevelInfos.qml
@@ -92,7 +92,7 @@ Page{
         Label{
             property int time : DB.getTime(diffSelected, levelSelected)
             anchors.horizontalCenter: parent.horizontalCenter
-            text: time===0?"xx:xx:xx":new Date(null, null, null, null, null, time).toTimeString().match(/\d{2}:\d{2}:\d{2}/)[0]
+            text: time===0?"xx:xx:xx":new Date(null, null, null, null, null, time).toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         }
     }
 }

--- a/qml/pages/WinPage.qml
+++ b/qml/pages/WinPage.qml
@@ -59,7 +59,7 @@ Dialog{
         Label{
             property int time : DB.getTime(game.diff, game.level)
             anchors.horizontalCenter: parent.horizontalCenter
-            text: time===0?"xx:xx:xx":Math.floor(time/3600)%216000+":"+Math.floor(time/60)%3600+":"+time%60
+            text: time===0?"xx:xx:xx":new Date(null, null, null, null, null, time).toTimeString().match(/\d{2}:\d{2}:\d{2}/)[0]
         }
         Label{
             visible: nextLevel === -1 && nextDiff === -1

--- a/qml/pages/WinPage.qml
+++ b/qml/pages/WinPage.qml
@@ -59,7 +59,7 @@ Dialog{
         Label{
             property int time : DB.getTime(game.diff, game.level)
             anchors.horizontalCenter: parent.horizontalCenter
-            text: time===0?"xx:xx:xx":new Date(null, null, null, null, null, time).toTimeString().match(/\d{2}:\d{2}:\d{2}/)[0]
+            text: time===0?"xx:xx:xx":new Date(null, null, null, null, null, time).toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         }
         Label{
             visible: nextLevel === -1 && nextDiff === -1


### PR DESCRIPTION
![screenshot-26-09-15-19-31-11_cropped](https://cloud.githubusercontent.com/assets/3757038/10163064/c4cbd89a-66b8-11e5-82e9-29e515f46d2e.png)

Before change the game used to show strings like "1:65:2",
which have wrong minutes and does not prepend single digit
minutes/seconds with zeroes.

toTimeString() function in qml on my device seems to give "hh:mm:ss"
right away, but on other js implementations it may give strings like
"14:07:21 GMT+0300 (MSK)", so match() should be kept as precaution.

Current code assume that playing time of a level is always less
than 23:59:59. Most likely assumption is correct but there is room for
improvement.
